### PR TITLE
Add AGENTS.md with Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+PHP library (Symfony bundle) providing Behat contexts for Doctrine ORM testing. No runtime services or databases needed — all tests use mocked EntityManager.
+
+### Dev commands
+
+All defined in `composer.json` scripts section:
+
+- `composer dev-checks` — runs validate + phpstan + phpcs + phpunit (use this as the full CI check)
+- `composer phpunit` — unit tests only
+- `composer phpstan` — static analysis (level max)
+- `composer code-style` — PHP_CodeSniffer (PSR-12 + Slevomat rules)
+- `composer code-style-fix` — auto-fix code style issues
+
+### Notes
+
+- PHP 8.3 is installed from the `ondrej/php` PPA. The package supports PHP 7.4–8.4.
+- No `composer.lock` is committed — `composer install` resolves from `composer.json` each time.
+- PHPUnit config uses `convertErrorsToExceptions`/`convertNoticesToExceptions`/`convertWarningsToExceptions` which emit deprecation notices on PHPUnit 9.6 but tests still pass.
+- `phpcs.xml.dist` has a deprecation warning about comma-separated array syntax for `forbiddenFunctions` property — cosmetic only, does not affect results.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working in this repository.

## Changes

- Created `AGENTS.md` documenting dev commands, PHP version requirements, and non-obvious caveats (no `composer.lock`, PHPUnit deprecation notices, phpcs deprecation warning).

## Verified

All development checks pass on PHP 8.3:

- `composer validate` — valid
- `composer phpstan` — no errors (level max)
- `composer code-style` — all 7 files pass (PSR-12 + Slevomat)
- `composer phpunit` — 38 tests, 111 assertions, all pass

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2e0f2a77-97c8-47d6-8705-a41e047a74ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2e0f2a77-97c8-47d6-8705-a41e047a74ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

